### PR TITLE
Fix compilation failure related to minwindef.h and missing <limits>

### DIFF
--- a/corral/Channel.h
+++ b/corral/Channel.h
@@ -264,7 +264,7 @@ struct Channel : public detail::channel::ReadHalf<T>,
             return 0;
         }
         if (!bounded_ && !closed_) {
-            return std::numeric_limits<size_t>::max();
+            return static_cast<size_t>(-1);
         }
         return buf_.capacity() - buf_.size();
     }


### PR DESCRIPTION
When both uv.h and corral.h are included, compilation fails on Windows because minwindef.h defines `max` as a macro, causing conflicts.
Additionally, corral.h uses std::numeric_limits without including <limits>, which may cause compilation failures on Linux and other platforms.