### PR TITLE
Update CMakeLists.txt to allow building with CMake 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
               sudo env PYTHONUNBUFFERED=1 ./vsdownload.py --accept-license --dest /opt/msvc
               sudo ./install.sh /opt/msvc
 
-            cmake_flags: -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_LINKER=link -DCMAKE_CXX_FLAGS_DEBUG="/MT /Zi /Ob0 /Od /RTC1" -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
+            cmake_flags: -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_LINKER=link -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
             env: PATH=/opt/msvc/bin/x64:$PATH
             cc: cl
             cxx: cl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 project(corral)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -7,6 +7,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_library(
   corral
+  INTERFACE
+)
+target_sources(corral
   INTERFACE
   corral/asio.h
   corral/CBPortal.h


### PR DESCRIPTION
We can use -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded to set /MT option since cmake 3.15 and later.
Reference: https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html

Um... By the way, I've only actually tested with CMake 3.18+.
