### PR TITLE
Assert parking lots have no suspended waiters at destruction

### DIFF
--- a/corral/detail/ParkingLot.h
+++ b/corral/detail/ParkingLot.h
@@ -37,6 +37,11 @@ template <class Self> class ParkingLotImpl {
     ParkingLotImpl() = default;
     ParkingLotImpl(ParkingLotImpl&&) = delete;
     ParkingLotImpl& operator=(ParkingLotImpl&&) = delete;
+    ~ParkingLotImpl() {
+        CORRAL_ASSERT(
+                parked_.empty() &&
+                "Still some tasks suspended while destroying a parking lot");
+    }
 
   protected:
     class Parked : public IntrusiveListItem<Parked> {


### PR DESCRIPTION
## Summary
- assert that a `ParkingLotImpl` is empty before its intrusive wait queue is destroyed
- extend the lifetime check already present on `Channel` to `Event`, `Semaphore`, and `ParkingLot`
- surface misuse at the destruction site instead of silently unlinking suspended awaiters and leaving their tasks stranded

## Validation
- `git diff --check`
- `printf '#include "corral/corral.h"\\nint main() { corral::Event e; corral::Semaphore s; corral::ParkingLot p; }\\n' | clang++ -std=c++20 -fsyntax-only -I. -x c++ -`
- `cmake -S . -B build -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DCORRAL_BOOST=/opt/include -DCORRAL_CATCH2=https://github.com/catchorg/catch2`
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure`
- focused Linux harness: empty destruction exited `0`; destruction with one parked waiter reached the custom `CORRAL_ASSERT` handler with exit `42`
