### PR TITLE
Fix Shared bool conversion

### DIFF
--- a/corral/Shared.h
+++ b/corral/Shared.h
@@ -78,7 +78,7 @@ template <class Awaitable> class Shared {
     Shared(std::in_place_t, Args&&... args);
 
     Awaitable* get() const;
-    explicit operator bool() const { return !state_; }
+    explicit operator bool() const { return static_cast<bool>(state_); }
     Awaitable& operator*() const { return *get(); }
     Awaitable* operator->() const { return get(); }
 

--- a/test/adapter_test.cc
+++ b/test/adapter_test.cc
@@ -190,6 +190,12 @@ CORRAL_TEST_CASE("shared") {
         co_await t.sleep(5ms);
         co_return 42;
     });
+    decltype(shared) empty;
+
+    CATCH_CHECK(shared);
+    CATCH_CHECK(shared.get() != nullptr);
+    CATCH_CHECK(!empty);
+    CATCH_CHECK(empty.get() == nullptr);
 
     auto use = [&](milliseconds delay = 0ms) -> Task<int> {
         if (delay != 0ms) {


### PR DESCRIPTION
Fixes #26.

`Shared::operator bool()` currently returns `!state_`, which makes a default-constructed empty `Shared` truthy and a constructed `Shared` falsey. That is the opposite of the existing `get()` semantics and the usual pointer-like contract used by `operator*`/`operator->`.

This changes the bool conversion to follow the underlying `IntrusivePtr` validity and adds coverage in the existing `shared` adapter test for both constructed and empty handles.

Validation:
- `git diff --check`
- `cmake -S . -B /tmp/corral-shared-bool-build -DSKIP_EXAMPLES=ON -DCORRAL_BOOST=''`
- standalone AppleClang 16 compile/link of `test/basic_test.cc` + `test/adapter_test.cc`, then `/tmp/corral-adapter-bool-build/corral_adapter_test shared` -> all 16 assertions passed