### PR TITLE
Work around bug in libc++ (clang) related to std::is_convertible

### DIFF
--- a/corral/Channel.h
+++ b/corral/Channel.h
@@ -33,6 +33,7 @@
 #include "config.h"
 #include "detail/ParkingLot.h"
 #include "detail/Queue.h"
+#include "detail/concept_helpers.h"
 
 namespace corral {
 
@@ -47,11 +48,11 @@ template <typename Half, typename... Args> class Awaiter;
 
 template <typename T, typename E>
 concept input_iterator_to =
-        std::input_iterator<T> && std::convertible_to<std::iter_value_t<T>, E>;
+        std::input_iterator<T> && std_convertible_to<std::iter_value_t<T>, E>;
 
 template <typename T, typename E>
 concept input_range_of = std::ranges::input_range<T> &&
-                         std::convertible_to<std::ranges::range_value_t<T>, E>;
+                         std_convertible_to<std::ranges::range_value_t<T>, E>;
 
 
 /// Interface for reading from a Channel. Exposed publicly as

--- a/corral/ErrorPolicy.h
+++ b/corral/ErrorPolicy.h
@@ -98,7 +98,7 @@ concept ApplicableErrorPolicy = requires {
     /// Extracts the error from the wrapped object.
     /// Should work on objects holding either an error or a value,
     /// and produce a default-constructed error type in the latter case.
-    { P::unwrapError(cw) } -> std::convertible_to<typename P::ErrorType>;
+    { P::unwrapError(cw) } -> detail::std_convertible_to<typename P::ErrorType>;
 
     /// Extracts the value from the wrapped object.
     /// Will only be called on wrapped objects holding a value.
@@ -132,7 +132,7 @@ concept ApplicableErrorPolicy = requires {
             P::template wrapValue<
                 decltype(P::template unwrapValue<Wrapped>(std::forward<Wrapped>(w)))
             >(P::template unwrapValue<Wrapped>(std::forward<Wrapped>(w)))
-        } -> std::convertible_to<Wrapped>;
+        } -> detail::std_convertible_to<Wrapped>;
 
     }) || (std::is_same_v<decltype(P::unwrapValue(std::declval<Wrapped>())), void> && requires {
         /// For void values, `wrapValue()` should return a wrapped object

--- a/corral/concepts.h
+++ b/corral/concepts.h
@@ -58,7 +58,7 @@ concept Awaiter = requires(T t, const T ct, Handle h) {
 #if !defined(__GNUC__) || defined(__llvm__) || __GNUC__ >= 11
   // gcc-10.2 fails to process the below
   && (std::is_same_v<Ret, detail::Unspecified> || requires(T t) {
-    { std::forward<T>(t).await_resume() } -> std::convertible_to<Ret>;
+    { std::forward<T>(t).await_resume() } -> detail::std_convertible_to<Ret>;
 })
 #endif
 ;

--- a/corral/detail/concept_helpers.h
+++ b/corral/detail/concept_helpers.h
@@ -32,9 +32,37 @@ namespace corral::detail {
 
 struct Unspecified {};
 
+/// Work around libc++ bug <https://github.com/llvm/llvm-project/issues/48959>,
+/// which causes std::is_convertible_v<void, std::optional<int>> (or any other
+/// optional type) to fail to compile, instead of just having that by false.
+/// This reimplements the type trait and concept, and forwards it to the
+/// standard library if From is not void, but simple returns false if it is.
+/// Use template matching instead of std::conditional or similar to ensure
+/// that std::is_convertible_v is never instantiated with From = void.
+template <class From, class To>
+struct std_is_convertible {
+    static constexpr const bool value = std::is_convertible_v<From, To>;
+};
+
+template <class To>
+struct std_is_convertible<void, To> : std::false_type {};
+
+template <>
+struct std_is_convertible<void, void> : std::true_type {};
+
+template <class From, class To>
+constexpr bool std_is_convertible_v = std_is_convertible<From, To>::value;
+
+template <class From, class To>
+concept std_convertible_to =
+        std_is_convertible_v<From, To> &&
+        requires {
+            static_cast<To>(std::declval<From>());
+        };
+
 template <class From, class To>
 concept convertible_to =
-        std::same_as<From, To> || std::convertible_to<From, To>;
+        std::same_as<From, To> || std_convertible_to<From, To>;
 
 template <class From, class... To>
 concept convertible_to_any = (convertible_to<From, To> || ...);

--- a/corral/detail/utility.h
+++ b/corral/detail/utility.h
@@ -494,7 +494,7 @@ AwaitableLambda<Callable> operator co_await(Callable&& c) {
 template <class Callable, class Ret>
     requires(std::derived_from<std::invoke_result_t<Callable>, TaskTag> &&
              (std::same_as<Ret, Unspecified> ||
-              std::convertible_to<
+              std_convertible_to<
                       typename std::invoke_result_t<Callable>::ReturnType,
                       Ret>) )
 constexpr bool ThisIsAwaitableTrustMe<Callable, Ret> = true;


### PR DESCRIPTION
clang when using libc++ will fail to compile the expression
`std::is_convertible_v<void, std::optional<int>>`, instead of just having that be false. See also:
<https://github.com/llvm/llvm-project/issues/48959>

Work around this by defining our own version that forwards to the std version, but in case void is used as the From parameter, always have that be false except if To is also void.

Also replace any usage of `std::is_convertible_v` / `std::convertible_to` where To is a generic type (and hence might be `std::optional`) to the `detail::std_is_convertible_v` / `detail::std_convertible_to` wrappers to avoid this issue from occurring.