### PR TITLE
Various improvements related to Boost ASIO integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if(NOT ${SKIP_TESTS})
     endif()
 
     add_executable(corral_asio_test test/asio_test.cc test/config.h test/config.h)
-    target_link_libraries(corral_asio_test PRIVATE corral Catch2::Catch2)
+    target_link_libraries(corral_asio_test PRIVATE corral Catch2::Catch2 ${CORRAL_BOOST_ASIO_LIB_NAME})
 
     if("${CORRAL_TEST_RUNNER}" STREQUAL "")
       message(STATUS "Trying to use installed OpenSSL.")

--- a/corral/asio.h
+++ b/corral/asio.h
@@ -27,6 +27,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/version.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include "detail/asio.h"
 

--- a/corral/asio.h
+++ b/corral/asio.h
@@ -64,15 +64,12 @@ struct BoostAsioImpl {
 };
 } // namespace corral::detail
 
-namespace boost::asio {
 template <bool ThrowOnError, class X, class... Ret>
-class async_result<::corral::detail::asio_awaitable_t<ThrowOnError>,
-                   X(boost::system::error_code, Ret...)>
+class boost::asio::async_result<::corral::detail::asio_awaitable_t<ThrowOnError>,
+                                X(boost::system::error_code, Ret...)>
   : public ::corral::detail::AsyncResultImpl<::corral::detail::BoostAsioImpl,
                                              ThrowOnError,
                                              Ret...> {};
-} // namespace boost::asio
-
 namespace corral {
 
 template <>

--- a/doc/01_getting_started.md
+++ b/doc/01_getting_started.md
@@ -26,10 +26,10 @@ distinguish them from async functions.)
 Here's our first async function, not that complicated or interesting yet:
 
 ```cpp
-boost::asio::io_service io_service;
+boost::asio::io_context io_context;
 corral::Task<void> async_hello() {
     std::cout << "getting ready..." << std::endl;
-    co_await corral::sleepFor(io_service, 100ms);
+    co_await corral::sleepFor(io_context, 100ms);
     std::cout << "Hello, world!" << std::endl;
 }
 ```
@@ -62,7 +62,7 @@ synchronous function (`main()`), how do we get to the point where we
 can run anything async?
 
 The answer is `corral::run()`, an ordinary (synchronous) function
-which accepts an event loop (such as the asio `io_service`) and an
+which accepts an event loop (such as the asio `io_context`) and an
 awaitable (most likely the task handle that's returned when you call
 an async function without `co_await`), and runs the event loop until
 the task represented by the awaitable completes. So to run the
@@ -70,7 +70,7 @@ the task represented by the awaitable completes. So to run the
 
 ```cpp
 int main() {
-    corral::run(io_service, wrap_hello());
+    corral::run(io_context, wrap_hello());
 }
 ```
 
@@ -89,7 +89,7 @@ corral::Task<void> hello_twice() {
     co_await corral::allOf(async_hello(), async_hello());
 }
 int main() {
-    corral::run(io_service, hello_twice());
+    corral::run(io_context, hello_twice());
 }
 ```
 
@@ -102,7 +102,7 @@ This outputs:
     Hello, world!
     Hello, world!
 
-While the first `co_await corral::sleepFor(io_service, 100ms)` was sleeping,
+While the first `co_await corral::sleepFor(io_context, 100ms)` was sleeping,
 the second one was also able to run. Awaiting something suspends the
 *current task* until the awaited operation completes, but other tasks can
 still run during that time.
@@ -162,7 +162,7 @@ several different cancellation models:
 * Attaching a timeout to a potentially long operation:
   ```cpp
   co_await corral::anyOf(somethingLong(),
-                         corral::sleepFor(io_service, 3s));
+                         corral::sleepFor(io_context, 3s));
   ```
 
 * Attaching a `corral::Event` to make something externally cancellable:
@@ -625,7 +625,7 @@ A relevant piece of code may look like this (error handling omitted
 for clarity):
 
 ```cpp
-asio::io_service io;
+asio::io_context io;
 corral::ThreadPool threadPool(io, /*threadCount = */ 8);
 
 struct SHA256 { char data[32] };

--- a/doc/03_live_objects.md
+++ b/doc/03_live_objects.md
@@ -27,7 +27,7 @@ to that reference may use it to spawn tasks into that nursery:
 ```cpp
 void delayedPrint(corral::Nursery& n) {
     n.start([]() -> corral::Task<> {
-        co_await corral::sleepFor(io_service, 1s);
+        co_await corral::sleepFor(io_context, 1s);
         std::cout << "Hello, world!" << std::endl;
     });
 }

--- a/doc/04_callback_bridging.md
+++ b/doc/04_callback_bridging.md
@@ -210,7 +210,7 @@ class MyReader : public IReader {
     // (The nursery doesn't directly use the event loop, but it needs
     // to be able to tell that its tasks are running "at the same time"
     // as other tasks that use this event loop.)
-    MyReader(boost::asio::io_service& io) : nursery_(io) {}
+    MyReader(boost::asio::io_context& io) : nursery_(io) {}
 
     void read(void* buf, size_t len, std::function<void(ssize_t)> cb) {
         nursery_.start([=]() -> corral::Task<> {
@@ -307,7 +307,7 @@ class MyReader: public IReader { // see above
     std::unique_ptr<corral::UnsafeNursery> nursery_;
 
   public:
-    MyReader(boost::asio::io_service& io):
+    MyReader(boost::asio::io_context& io):
         nursery_(std::make_unique<corral::UnsafeNursery>(io));
 
     ~MyReader() {

--- a/examples/asio_happy_eyeballs.cc
+++ b/examples/asio_happy_eyeballs.cc
@@ -108,8 +108,8 @@ int main(int argc, char** argv) {
     boost::asio::io_context io_context(1);
     tcp::resolver resolver(io_context);
     auto endpoints = corral::run(
-            io_service,
-            resolver.async_resolve(tcp::resolver::query{argv[1], argv[2]},
+            io_context,
+            resolver.async_resolve(argv[1], argv[2],
                                    corral::asio_awaitable));
     auto delay = boost::posix_time::milliseconds(std::stoi(argv[3]));
     auto sock = corral::run(

--- a/examples/asio_happy_eyeballs.cc
+++ b/examples/asio_happy_eyeballs.cc
@@ -40,7 +40,7 @@ using tcp = boost::asio::ip::tcp;
 /// fails, or after `delay` milliseconds since it started, whichever comes
 /// first.
 corral::Task<std::optional<tcp::socket>> happy_eyeballs_connect(
-        boost::asio::io_service& io_service,
+        boost::asio::io_context& io_context,
         std::ranges::range auto endpoints,
         boost::posix_time::milliseconds delay) {
     std::optional<tcp::socket> result;
@@ -62,7 +62,7 @@ corral::Task<std::optional<tcp::socket>> happy_eyeballs_connect(
             // Start the connection attempt in background
             // (as we don't want it cancelled after `delay`).
             nursery.start([&, addr, kickOffNext]() -> corral::Task<void> {
-                tcp::socket sock(io_service);
+                tcp::socket sock(io_context);
                 std::cout << "trying " << addr << "...\n";
                 auto ec = co_await sock.async_connect(
                         addr, corral::asio_nothrow_awaitable);
@@ -85,7 +85,7 @@ corral::Task<std::optional<tcp::socket>> happy_eyeballs_connect(
             // As kickOffNext() is idempotent, we can do it unconditionally
             // upon timeout expiration, not caring about whether the lambda
             // above has already done so.
-            co_await corral::sleepFor(io_service, delay);
+            co_await corral::sleepFor(io_context, delay);
             kickOffNext();
         };
 
@@ -105,14 +105,14 @@ int main(int argc, char** argv) {
         throw std::runtime_error(
                 "usage: asio_happy_eyeballs <host> <port> <delay_ms>");
     }
-    boost::asio::io_service io_service(1);
-    tcp::resolver resolver(io_service);
+    boost::asio::io_context io_context(1);
+    tcp::resolver resolver(io_context);
     auto endpoints = corral::run(
             io_service,
             resolver.async_resolve(tcp::resolver::query{argv[1], argv[2]},
                                    corral::asio_awaitable));
     auto delay = boost::posix_time::milliseconds(std::stoi(argv[3]));
     auto sock = corral::run(
-            io_service, happy_eyeballs_connect(io_service, endpoints, delay));
+            io_context, happy_eyeballs_connect(io_context, endpoints, delay));
     return sock ? 0 : 1;
 }

--- a/examples/asio_hello_world.cc
+++ b/examples/asio_hello_world.cc
@@ -32,11 +32,11 @@
 
 using namespace std::chrono_literals;
 
-boost::asio::io_service io_service;
+boost::asio::io_context io_context;
 
 corral::Task<void> greet(std::string name) {
     std::cout << "Hello..." << std::endl;
-    co_await corral::sleepFor(io_service, 1s);
+    co_await corral::sleepFor(io_context, 1s);
     std::cout << "..." << name << std::endl;
 }
 
@@ -46,5 +46,5 @@ corral::Task<void> greetThings() {
 }
 
 int main(int argc, char** argv) {
-    corral::run(io_service, greetThings());
+    corral::run(io_context, greetThings());
 }

--- a/examples/asio_http_downloader.cc
+++ b/examples/asio_http_downloader.cc
@@ -60,8 +60,8 @@ corral::Task<void> http_download(
     // Resolve and connect
     tcp::resolver resolver(io_context);
     auto endpoints = co_await resolver.async_resolve(
-            tcp::resolver::query{host, "http"}, corral::asio_awaitable);
-    tcp::socket sock(io_service);
+            host, "http", corral::asio_awaitable);
+    tcp::socket sock(io_context);
     co_await asio::async_connect(sock, endpoints, corral::asio_awaitable);
 
     // Make and send HTTP request

--- a/examples/asio_http_downloader.cc
+++ b/examples/asio_http_downloader.cc
@@ -40,7 +40,7 @@ namespace http = beast::http;
 /// An example function which downloads a file over HTTP using multiple
 /// concurrent conections.
 corral::Task<void> http_download(
-        asio::io_service& io_service,
+        asio::io_context& io_context,
         std::string url,
         std::ofstream& out,
         std::variant<int /*concurrency*/,
@@ -58,7 +58,7 @@ corral::Task<void> http_download(
     std::string path = url.substr(slash);
 
     // Resolve and connect
-    tcp::resolver resolver(io_service);
+    tcp::resolver resolver(io_context);
     auto endpoints = co_await resolver.async_resolve(
             tcp::resolver::query{host, "http"}, corral::asio_awaitable);
     tcp::socket sock(io_service);
@@ -98,7 +98,7 @@ corral::Task<void> http_download(
             for (size_t bound = chunkSize; bound < totalSize;
                  bound += chunkSize) {
                 nursery.start(
-                        http_download, std::ref(io_service), url, std::ref(out),
+                        http_download, std::ref(io_context), url, std::ref(out),
                         std::make_pair(bound,
                                        std::min(chunkSize, totalSize - bound)));
                 ofs = bound;

--- a/examples/asio_netcat.cc
+++ b/examples/asio_netcat.cc
@@ -61,7 +61,7 @@ corral::Task<void> netcat(boost::asio::io_context& io_context,
 
     // Resolve a DNS name and connect
     tcp::resolver::results_type endpoints = co_await resolver.async_resolve(
-            {host, port}, corral::asio_awaitable);
+            host, port, corral::asio_awaitable);
     co_await boost::asio::async_connect(sock, endpoints,
                                         corral::asio_awaitable);
 


### PR DESCRIPTION
There were a couple of issues in corral when using it with the newest Boost version:

 - Use of the deprecated `boost::io_service` (replacement: `boost::io_context`)
 - Use of the deprecated `resolver::query` (replacement: direct parameters for `async_resolve`)
 - Missing include for `posix_time` (not automatic in newer Boost versions)

Additionally, in specialized setups where `bcp --namespace` was used during the build of the Boost library, the specialization of `boost::asio::async_result` would fail to compile. An additional commit reworks the specialization so that it works in all cases.