### PR TITLE
adapter_test: define _USE_MATH_DEFINES on Windows, not just with MSVC

### DIFF
--- a/test/adapter_test.cc
+++ b/test/adapter_test.cc
@@ -23,7 +23,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #define _USE_MATH_DEFINES 1
 #endif
 


### PR DESCRIPTION
MinGW/GCC also follows MSVC when it comes to the behavior of `<cmath>`, in that `_USE_MATH_DEFINES` must be defined for `M_PI` etc. to be defined as macros after including the header.

Replace `#ifdef _MSC_VER` with a global check for `_WIN32` (which is also defined on 64bit Windows), so that this behavior happens on Windows universally, irrespective of the compiler used.