### PR TITLE
Fix Value lvalue predicates

### DIFF
--- a/corral/Value.h
+++ b/corral/Value.h
@@ -286,7 +286,8 @@ template <class T>
 template <class Fn>
 class Value<T>::UntilMatches : public AwaiterBase {
   public:
-    UntilMatches(Value& cond, Fn fn) : AwaiterBase(cond), fn_(std::move(fn)) {
+    UntilMatches(Value& cond, Fn&& fn)
+      : AwaiterBase(cond), fn_(std::forward<Fn>(fn)) {
         if (fn_(cond.value_)) {
             result_ = cond.value_;
         }
@@ -349,8 +350,8 @@ template <class T>
 template <class Fn>
 class Value<T>::UntilChanged : public AwaiterBase {
   public:
-    explicit UntilChanged(Value& cond, Fn fn)
-      : AwaiterBase(cond), fn_(std::move(fn)) {}
+    explicit UntilChanged(Value& cond, Fn&& fn)
+      : AwaiterBase(cond), fn_(std::forward<Fn>(fn)) {}
 
     bool await_ready() const noexcept { return false; }
     std::pair<T, T> await_resume() && { return std::move(*result_); }

--- a/test/sync_primitive_test.cc
+++ b/test/sync_primitive_test.cc
@@ -211,4 +211,27 @@ CORRAL_TEST_CASE("value") {
             });
 }
 
+CORRAL_TEST_CASE("value-lvalue-predicates") {
+    Value<int> v{0};
+    auto matchesOne = [](const int& value) { return value == 1; };
+    auto changesFromOneToTwo = [](const int& from, const int& to) {
+        return from == 1 && to == 2;
+    };
+
+    co_await allOf(
+            [&]() -> Task<> {
+                CATCH_CHECK(co_await v.untilMatches(matchesOne) == 1);
+                auto [from, to] =
+                        co_await v.untilChanged(changesFromOneToTwo);
+                CATCH_CHECK(from == 1);
+                CATCH_CHECK(to == 2);
+            },
+            [&]() -> Task<> {
+                v = 1;
+                co_await yield;
+                v = 2;
+            });
+    CATCH_CHECK(t.now() == 0ms);
+}
+
 } // namespace


### PR DESCRIPTION
## Problem

`Value::untilMatches()` and `untilChanged()` accept forwarding references, but their awaiters take the deduced callable type by value and then unconditionally move it into storage. Passing a named predicate deduces a reference type, so the constructor tries to initialize a reference member from an rvalue and fails to compile.

## Change

- Make the awaiter constructors take `Fn&&` and forward the predicate into storage.
- Add a regression test that `co_await`s both operations with named predicates.

This keeps the existing behavior: lvalue predicates are referenced, while rvalue predicates are owned by the awaiter.

## Validation

- Compiled the modified test translation unit with AppleClang.
- Ran the complete unit suite with PR #28 applied in the validation worktree for the existing Apple libc++ compatibility issue: all tests passed.