### PR TITLE
Support throwing move-only types in Channel

### DIFF
--- a/corral/detail/Queue.h
+++ b/corral/detail/Queue.h
@@ -203,7 +203,8 @@ class Queue {
     }
 
     static auto moveRange(auto it, auto ie, auto dst) {
-        if constexpr (std::is_nothrow_move_constructible_v<T>) {
+        if constexpr (std::is_nothrow_move_constructible_v<T> ||
+                      !std::is_copy_constructible_v<T>) {
             return std::uninitialized_move(it, ie, dst);
         } else {
             return std::uninitialized_copy(it, ie, dst);

--- a/test/channel_test.cc
+++ b/test/channel_test.cc
@@ -209,6 +209,32 @@ CORRAL_TEST_CASE("bounded-channel-close") {
 // Unbounded channels
 //
 
+struct ThrowingMoveOnly {
+    explicit ThrowingMoveOnly(int value) : value(value) {}
+
+    ThrowingMoveOnly(const ThrowingMoveOnly&) = delete;
+    ThrowingMoveOnly(ThrowingMoveOnly&& other) noexcept(false)
+      : value(other.value) {}
+
+    int value;
+};
+
+CORRAL_TEST_CASE("unbounded-channel-throwing-move-only") {
+    Channel<ThrowingMoveOnly> channel;
+
+    for (int i = 0; i < 20; ++i) {
+        CATCH_REQUIRE(channel.trySend(ThrowingMoveOnly(i)));
+    }
+
+    for (int i = 0; i < 20; ++i) {
+        auto value = channel.tryReceive();
+        CATCH_REQUIRE(value.has_value());
+        CATCH_CHECK(value->value == i);
+    }
+
+    co_return;
+}
+
 CORRAL_TEST_CASE("unbounded-channel-smoke") {
     Channel<int> channel;
 


### PR DESCRIPTION
## Problem

`Queue<T>` supports move-only element types, but queue growth copies whenever `T` is not nothrow-move-constructible. For a move-only type with a potentially-throwing move constructor, this selects `std::uninitialized_copy` and fails to compile.

An unbounded `Channel<T>` encounters this on its first send because its queue starts with zero capacity.

## Change

Move existing elements when moving is noexcept or copying is unavailable, matching the selection rule used by `std::move_if_noexcept`. Copyable types with potentially-throwing moves retain the current copy path.

Add a regression test that sends 20 move-only values through an unbounded channel and receives them in order, exercising multiple queue growth points.

## Validation

Ran the complete test suite with AddressSanitizer and UndefinedBehaviorSanitizer: all tests passed. PR #28 was applied only in the validation worktree for the existing Apple libc++ compatibility issue.