### PR TITLE
Guard asio-standalone.h against multiple inclusion

### DIFF
--- a/corral/asio-standalone.h
+++ b/corral/asio-standalone.h
@@ -23,6 +23,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+#pragma once
+
 #include <asio.hpp>
 #include <asio/version.hpp>
 #include <system_error>

--- a/test/asio_test.cc
+++ b/test/asio_test.cc
@@ -40,6 +40,7 @@
 #include <asio.hpp>
 
 #include "../corral/asio-standalone.h"
+#include "../corral/asio-standalone.h"
 #define CORRAL_ASIOS                                                           \
     corral::detail::BoostAsioImpl, corral::detail::StandaloneAsioImpl
 #else


### PR DESCRIPTION
## Problem

`corral/asio-standalone.h` has no include guard. Including it more than once, directly or through separate dependencies, redefines the standalone Asio adapter and its specializations.

## Change

- Add `#pragma once`, consistent with the other Corral headers.
- Include the header twice in the existing standalone-Asio test translation unit.

## Validation

Built and ran `corral_asio_test` with both Boost.Asio and standalone Asio enabled: 10 test cases and 27 assertions passed.